### PR TITLE
Add Chinese code and service patterns

### DIFF
--- a/src/assets/libs/parse-otp-message/index.js
+++ b/src/assets/libs/parse-otp-message/index.js
@@ -140,9 +140,9 @@ function validateAuthCodeMatch(message, index, code, cleanCode) {
   if (index + code.length < message.length) {
     const next = message.charAt(index + code.length)
     // make sure next character is whitespace or ending grammar
-    if (next && [/\s/g, ",", ".", "!", " "].indexOf(next) < 1) {
+    if (next && [/\s/g, ",", ".", "!", " ", "，", "。"].indexOf(next) < 1) {
       return;
-    };
+    }
   }
 
   return cleanCode(code)
@@ -156,7 +156,7 @@ function inferService(message) {
     const match = s.match(pattern)
     const service = match && match[1] && match[1].trim()
 
-    if (service && /\w+/.test(service) && !authWords.has(service)) {
+    if (service && service !== "" && !authWords.has(service)) {
       // check for some false-positive cases
       if (stopwords.has(service)) {
         if (message.substr(match.index, service.length) !== service.toUpperCase()) {

--- a/src/assets/libs/parse-otp-message/lib/service-patterns.js
+++ b/src/assets/libs/parse-otp-message/lib/service-patterns.js
@@ -121,5 +121,7 @@ module.exports = [
 
   /\b([\w\d]{3,64})\s+code\b/,
   /\b([\w\d]{3,64})\s+number\b/,
-  /\b([\w\d]{3,64})\s+pin\b/
+  /\b([\w\d]{3,64})\s+pin\b/,
+
+  /【([\u4e00-\u9fa5\d\w]+)】/
 ]

--- a/src/assets/libs/parse-otp-message/test/custom.js
+++ b/src/assets/libs/parse-otp-message/test/custom.js
@@ -4,7 +4,10 @@ const trickyStrings = [
     "588873 is the OTP for transaction of INR 3373.00 on your Kotak Bank Card 9688 at AMAZON PAY INDIA PRIVATET valid for 15 mins. DONT SHARE OTP WITH ANYONE INCLUDING BANK OFFICIALS.",
     "342562 is your Twitter authentication code. Don’t reply to this message with your code.?",
     "Verizon One Time Passcode. Your One Time Passcode is 193667. Please do not share this One Time Passcode with anyone.",
-    "Verizon Msg: Verizon won’t call you for this code. The authorization code you requested for sign in is 779065. Please use this code to complete your request."
+    "Verizon Msg: Verizon won’t call you for this code. The authorization code you requested for sign in is 779065. Please use this code to complete your request.",
+    "验证码：805281，用于华为帐号登录。转给他人将导致华为帐号被盗和个人信息泄露，谨防诈骗。【华为】",
+    "【微信支付】验证码为940816，用于商户平台安全验证，5分钟内有效。若非本人操作，请忽略此消息。",
+    "【iSlide】验证码927134，您正在登录iSlide，若非本人操作，请勿泄露。"
 ]
 
 const test = () => {

--- a/src/assets/libs/parse-otp-message/test/index.js
+++ b/src/assets/libs/parse-otp-message/test/index.js
@@ -454,7 +454,28 @@ const testCases = [
       code: '123ABC78',
       service: 'exampleapp'
     }
-  }
+  },
+  {
+    message: `验证码：805281，用于华为帐号登录。转给他人将导致华为帐号被盗和个人信息泄露，谨防诈骗。【华为】`,
+    result: {
+      code: '805281',
+      service: '华为'
+    }
+  },
+  {
+    message: `【微信支付】验证码为940816，用于商户平台安全验证，5分钟内有效。若非本人操作，请忽略此消息。`,
+    result: {
+      code: '940816',
+      service: '微信支付'
+    }
+  },
+  {
+    message: `【iSlide】验证码927134，您正在登录iSlide，若非本人操作，请勿泄露。`,
+    result: {
+      code: '927134',
+      service: 'islide'
+    }
+  },
 ]
 
 testCases.forEach((testCase) => {


### PR DESCRIPTION
Try to add Chinese support for code and service patterns.
The Chinese code is same as English for 4-8 digital numbers.
The service pattern is `【([\u4e00-\u9fa5\d\w]+)】` which will support for 【微信支付】 【华为】 【iSlide】 【360】.